### PR TITLE
Fixed ContentViewDefinition's 'show' method to return the json object

### DIFF
--- a/src/katello/client/api/content_view_definition.py
+++ b/src/katello/client/api/content_view_definition.py
@@ -39,7 +39,7 @@ class ContentViewDefinitionAPI(KatelloAPI):
     def show(self, org_id, cvd_id):
         path = "/api/organizations/%s/content_view_definitions/%s" % (org_id,
                 cvd_id)
-        cvd = self.server.GET(path)
+        cvd = self.server.GET(path)[1]
         return cvd
 
     def create(self, org_id, name, label, description, composite=False):


### PR DESCRIPTION
Current 'show' method for ContentViewDefinition returns the entire response object:

``` python
(200,
 {u'components': [],
  u'composite': False,
  u'content_views': [u'PublishedCVD1'],
  u'created_at': u'2013-06-11T18:08:21Z',
  u'description': u'Created on 2013-06-11-14-08-18',
  u'id': 12,
  u'label': u'label-cvd1',
  u'name': u'CVD1',
  u'organization': u'stressorg',
  u'organization_id': 5,
  u'products': [u'product1'],
  u'repos': [],
  u'source_id': None,
  u'type': u'ContentViewDefinition',
  u'updated_at': u'2013-06-11T18:08:21Z'},
 [('x-request-id', '18ac8fdc97d53059aad3efa474e0e9c1'),
  ('transfer-encoding', 'chunked'),
  ('server', 'thin 1.3.1 codename Triple Espresso'),
  ('x-runtime', '0.020186'),
  ('etag', '"39eaafbe654ea0768cc1cfd3296b4c50"'),
  ('x-ua-compatible', 'IE=Edge,chrome=1'),
  ('cache-control', 'must-revalidate, private, max-age=0'),
  ('date', 'Tue, 11 Jun 2013 19:03:27 GMT'),
  ('x-candlepin-version', 'katello/1.4.2-11.el6sat'),
  ('content-type', 'application/json; charset=utf-8'),
  ('x-rack-cache', 'miss')])
```

Instead it should return only the ContentViewDefinition object:

``` python
{u'components': [],
 u'composite': False,
 u'content_views': [u'PublishedCVD1'],
 u'created_at': u'2013-06-11T18:08:21Z',
 u'description': u'Created on 2013-06-11-14-08-18',
 u'id': 12,
 u'label': u'label-cvd1',
 u'name': u'CVD1',
 u'organization': u'stressorg',
 u'organization_id': 5,
 u'products': [u'product1'],
 u'repos': [],
 u'source_id': None,
 u'type': u'ContentViewDefinition',
 u'updated_at': u'2013-06-11T18:08:21Z'}
```
