### PR TITLE
system-tests - The environment is needed for RHSM registration

### DIFF
--- a/system-test/cli_tests/provider_import.sh
+++ b/system-test/cli_tests/provider_import.sh
@@ -60,7 +60,7 @@ if sm_present; then
     skip_message "rhsm registration" "Could not test against hosted"
   else
     test_own_cmd_success "rhsm registration with org" $SUDO subscription-manager register --username="$USER" --password="$PASSWORD" \
-      --org="$MANIFEST_ORG" --name="$HOST" --force
+      --org="$MANIFEST_ORG" --environment="$MANIFEST_ENV" --name="$HOST" --force
     test_own_cmd_success "rhsm subscribe to pool" $SUDO subscription-manager subscribe --pool "$POOLID"
     $SUDO yum remove -y "$INSTALL_PACKAGE" &> /dev/null
     test_own_cmd_success "install package from subscribed product" $SUDO yum install -y "$INSTALL_PACKAGE" --nogpgcheck --releasever "$RELEASEVER" --disablerepo \* --enablerepo "$MANIFEST_REPO_LABEL" &> /dev/null
@@ -73,7 +73,7 @@ if sm_present; then
 
     test_own_cmd_success "rhsm list available SLAs" $SUDO subscription-manager service-level --list --org="$MANIFEST_ORG"  --username="$USER" --password="$PASSWORD"
     test_own_cmd_exit_code 1 "rhsm registration with SLA" $SUDO subscription-manager register --username="$USER" --password="$PASSWORD" \
-      --org="$MANIFEST_ORG" --name="$HOST" --servicelevel="$SLA" --autosubscribe --force
+      --org="$MANIFEST_ORG" --environment="$MANIFEST_ENV" --name="$HOST" --servicelevel="$SLA" --autosubscribe --force
     test_own_cmd_success "rhsm unregister" $SUDO subscription-manager unregister
   fi
 else

--- a/system-test/cli_tests/rhsm.sh
+++ b/system-test/cli_tests/rhsm.sh
@@ -50,10 +50,10 @@ if sm_present; then
     test_own_cmd_success "rhsm show organizations" $SUDO subscription-manager orgs --username="$USER" --password="$PASSWORD"
     test_own_cmd_success "rhsm show environments" $SUDO subscription-manager environments --username="$USER" --password="$PASSWORD" --org="$RHSM_ORG"
     test_own_cmd_success "rhsm registration with org label" \
-      $SUDO subscription-manager register --username="$USER" --password="$PASSWORD" --org="$RHSM_ORG_LABEL" --name="$HOST" --force
+      $SUDO subscription-manager register --username="$USER" --password="$PASSWORD" --org="$RHSM_ORG_LABEL" --environment="$RHSM_ENV" --name="$HOST" --force
     test_own_cmd_success "rhsm unregister" $SUDO subscription-manager unregister
     test_own_cmd_success "rhsm registration with org name" \
-      $SUDO subscription-manager register --username="$USER" --password="$PASSWORD" --org="$RHSM_ORG" --name="$HOST" --force
+      $SUDO subscription-manager register --username="$USER" --password="$PASSWORD" --org="$RHSM_ORG" --environment="$RHSM_ENV" --name="$HOST" --force
     test_own_cmd_success "rhsm show identity" $SUDO subscription-manager identity
     test_own_cmd_success "rhsm registration with org/env" $SUDO subscription-manager register --username="$USER" --password="$PASSWORD" \
       --org="$RHSM_ORG" --environment="$RHSM_ENV" --name="$HOST" --force
@@ -86,7 +86,7 @@ if sm_present; then
 
     # testing auto-unsubscribe
     test_own_cmd_success "rhsm registration with org" $SUDO subscription-manager register --username="$USER" \
-        --password="$PASSWORD" --org="$RHSM_ORG" --force
+        --password="$PASSWORD" --environment="$RHSM_ENV" --org="$RHSM_ORG" --force
     name1=$($SUDO subscription-manager identity | grep -o -E "^name:.*")
     name=${name1:6} # grab name
     test_success "system unregister in katello" system unregister --name="$name" --org="$RHSM_ORG"


### PR DESCRIPTION
This was changed since the systems can subscribe to Library.
