### PR TITLE
add get_deleted_consumers call

### DIFF
--- a/src/katello/client/api/system.py
+++ b/src/katello/client/api/system.py
@@ -207,3 +207,7 @@ class SystemAPI(KatelloAPI):
     def remove_consumer_deletion_record(self, uuid):
         path = "/api/consumers/%s/deletionrecord" % uuid
         return self.server.DELETE(path)[1]
+
+    def get_deleted_consumers(self):
+        path = "/api/deleted_consumers"
+        return self.server.GET(path)[1]


### PR DESCRIPTION
Add an API binding so I can grab the list of deleted consumers.

:point_right: Note that the PR to expose this api in katello isn't merged yet; this change is additive so it shouldn't break anything by merging before the other PR is merged.
