### PR TITLE
Fix for some system tests

### DIFF
--- a/system-test/cli_tests/_base_setup.sh
+++ b/system-test/cli_tests/_base_setup.sh
@@ -36,5 +36,7 @@ test_success "content definition create ($TEST_DEF)" content definition create -
 test_success "content definition add_repo ($FEWUPS_REPO to $TEST_DEF)" content definition add_repo --org="$TEST_ORG" --name="$TEST_DEF" --product=$FEWUPS_PRODUCT --repo="$FEWUPS_REPO"
 test_success "content definition publish ($TEST_DEF to $TEST_VIEW)" content definition publish --org=$TEST_ORG --label=$TEST_DEF --view_name=$TEST_VIEW
 test_success "content view promote ($TEST_VIEW to $TEST_ENV)" content view promote --org="$TEST_ORG" --name="$TEST_VIEW" --env="$TEST_ENV"
+test_success "content view promote ($TEST_VIEW to $TEST_ENV_2)" content view promote --org="$TEST_ORG" --name="$TEST_VIEW" --env="$TEST_ENV_2"
+
 REPO_NAME=$(get_repo_name)
 REPO_ID=$(get_repo_id)


### PR DESCRIPTION
One of the system tests required a system to get migrated to a
new environment. So added a step to promote the Content View from
TEST_ENV to TEST_ENV_2 so that the same cv is availbale in the new
environment
