### PR TITLE
Fix content views handling in system tests

### DIFF
--- a/system-test/cli_tests/changeset.sh
+++ b/system-test/cli_tests/changeset.sh
@@ -6,6 +6,9 @@ header "Changeset"
 #test_success "repo synchronize" repo synchronize --id="$REPO_ID"
 test_success "product synchronize" product synchronize --org="$TEST_ORG" --name="$FEWUPS_PRODUCT"
 
+CS_TEST_VIEW="${TEST_VIEW}_cs"
+test_success "content definition publish ($TEST_DEF to $CS_TEST_VIEW)" content definition publish --org=$TEST_ORG --label=$TEST_DEF --view_name=$CS_TEST_VIEW
+
 # testing changesets
 CS_NAME="changeset_$RAND"
 CS_NAME_2="changeset_2_$RAND"
@@ -21,7 +24,7 @@ test_success "changeset create" changeset create --org="$TEST_ORG" --environment
 test_failure "changeset add package"  changeset update  --org="$TEST_ORG" --environment="$TEST_ENV" --name="$CS_NAME_2" --from_product="$FEWUPS_PRODUCT" --add_package="monkey-0.3-0.8.noarch"
 test_failure "changeset add erratum"  changeset update  --org="$TEST_ORG" --environment="$TEST_ENV" --name="$CS_NAME_2" --from_product="$FEWUPS_PRODUCT" --add_erratum="RHEA-2010:0001"
 test_failure "changeset add repo"     changeset update  --org="$TEST_ORG" --environment="$TEST_ENV" --name="$CS_NAME_2" --from_product="$FEWUPS_PRODUCT" --add_repo="$REPO_NAME"
-test_success "changeset add view"     changeset update  --org="$TEST_ORG" --environment="$TEST_ENV" --name="$CS_NAME_2" --add_content_view="$TEST_VIEW"
+test_success "changeset add view"     changeset update  --org="$TEST_ORG" --environment="$TEST_ENV" --name="$CS_NAME_2" --add_content_view="$CS_TEST_VIEW"
 
 test_success "changeset promote" changeset promote --org="$TEST_ORG" --environment="$TEST_ENV" --name="$CS_NAME_2"
 
@@ -32,6 +35,6 @@ test_failure "changeset remove product"  changeset update  --org="$TEST_ORG" --e
 test_failure "changeset remove package"  changeset update  --org="$TEST_ORG" --environment="$TEST_ENV" --name="$CS_NAME_2" --from_product="$FEWUPS_PRODUCT" --remove_package="monkey-0.3-0.8.noarch"
 test_failure "changeset remove erratum"  changeset update  --org="$TEST_ORG" --environment="$TEST_ENV" --name="$CS_NAME_2" --from_product="$FEWUPS_PRODUCT" --remove_erratum="RHEA-2010:0001"
 test_failure "changeset remove repo"     changeset update  --org="$TEST_ORG" --environment="$TEST_ENV" --name="$CS_NAME_2" --from_product="$FEWUPS_PRODUCT" --remove_repo="$REPO_NAME"
-test_success "changeset remove view"     changeset update  --org="$TEST_ORG" --environment="$TEST_ENV" --name="$CS_NAME_2" --remove_content_view_label="$TEST_VIEW"
+test_success "changeset remove view"     changeset update  --org="$TEST_ORG" --environment="$TEST_ENV" --name="$CS_NAME_2" --remove_content_view_label="$CS_TEST_VIEW"
 
 test_success "changeset update" changeset update --org="$TEST_ORG" --environment="$TEST_ENV" --name="$CS_NAME" --new_name="new_$CS_NAME" --description="updated description"

--- a/system-test/cli_tests/provider_import.sh
+++ b/system-test/cli_tests/provider_import.sh
@@ -12,6 +12,8 @@ fi
 
 MANIFEST_ORG="org_manifest_$RAND"
 MANIFEST_ENV="env_manifest_$RAND"
+MANIFEST_DEF="cvdef_manifest_$RAND"
+MANIFEST_VIEW="cv_manifest_$RAND"
 MANIFEST_AK1=$(nospace "manifest_ak1_$RAND")
 MANIFEST_AK2=$(nospace "manifest_ak2_$RAND")
 CS1_NAME="changeset_manifest_$RAND"
@@ -38,8 +40,13 @@ test_success "enable repo set" product repository_set_enable --name="$MANIFEST_E
 test_success "products refresh" provider refresh_products --name "Red Hat" --org "$MANIFEST_ORG"
 test_success "repo enable" repo enable --name="$MANIFEST_REPO" --product "$MANIFEST_EPROD" --org "$MANIFEST_ORG"
 test_success "repo synchronize" repo synchronize --name="$MANIFEST_REPO" --product "$MANIFEST_EPROD" --org "$MANIFEST_ORG"
+
+test_success "content definition create ($MANIFEST_DEF)" content definition create --org="$MANIFEST_ORG" --name="$MANIFEST_DEF"
+test_success "content definition add_repo ($MANIFEST_REPO to $MANIFEST_DEF)" content definition add_repo --org="$MANIFEST_ORG" --name="$MANIFEST_DEF" --product="$MANIFEST_EPROD" --repo="$MANIFEST_REPO"
+test_success "content definition publish ($MANIFEST_DEF to $MANIFEST_VIEW)" content definition publish --org=$MANIFEST_ORG --label=$MANIFEST_DEF --view_name=$MANIFEST_VIEW
+
 test_success "changeset create" changeset create --org="$MANIFEST_ORG" --environment="$MANIFEST_ENV" --name="$CS1_NAME"
-test_success "changeset add view" changeset update  --org="$MANIFEST_ORG" --environment="$MANIFEST_ENV" --name="$CS1_NAME" --add_content_view="$TEST_VIEW"
+test_success "changeset add view" changeset update  --org="$MANIFEST_ORG" --environment="$MANIFEST_ENV" --name="$CS1_NAME" --add_content_view="$MANIFEST_VIEW"
 check_delayed_jobs_running
 test_success "changeset promote" changeset promote --org="$MANIFEST_ORG" --environment="$MANIFEST_ENV" --name="$CS1_NAME"
 POOLID=$($CMD org subscriptions --name "$MANIFEST_ORG" -g -d ";" --noheading | grep "$MANIFEST_PROD_CP" | awk -F ';' '{print $3}') # grab a pool for CP


### PR DESCRIPTION
The global content view "$TEST_VIEW" was incorrectly used in various places.
