### PR TITLE
Removed 'id' on filter create

### DIFF
--- a/src/katello/client/core/filter.py
+++ b/src/katello/client/core/filter.py
@@ -148,7 +148,9 @@ class Info(FilterAction):
 class Create(FilterAction):
     description = _('create a filter')
     def setup_parser(self, parser):
-        self._add_get_filter_opts(parser)
+        FilterAction._add_cvd_filter_opts(parser)
+        parser.add_option('--name', dest='name',
+                help=_("filter name eg: 'package filter acme'"))
         opt_parser_add_org(parser, required=1)
 
     def check_options(self, validator):


### PR DESCRIPTION
Related to BZ 1004240 .  Basically --id was included as an option for filter create even though we do not let the user provide ids on create.
