### PR TITLE
990476: system_group: improve behavior of [add|remove]_systems

### DIFF
--- a/src/katello/client/api/utils.py
+++ b/src/katello/client/api/utils.py
@@ -284,6 +284,25 @@ def get_system(org_name, sys_name, env_name=None, sys_uuid=None):
 
     return system_api.system(systems[0]['uuid'])
 
+def get_systems(org_name, sys_uuids):
+    invalid_sys_uuids = []
+    systems = []
+
+    for sys_uuid in sys_uuids:
+        try:
+            system = get_system(org_name, None, None, sys_uuid)
+            systems.append(system)
+
+        except ApiDataError:
+            invalid_sys_uuids.append(sys_uuid)
+
+    if len(invalid_sys_uuids) > 0:
+        raise ApiDataError(_("Could not find Systems [ %(sys_uuids)s ] in Org [ %(org_name)s ]") \
+            % {'sys_uuids':', '.join(sys_uuid for sys_uuid in invalid_sys_uuids),
+               'org_name':org_name})
+
+    return systems
+
 def get_distributor(org_name, dist_name, env_name=None, dist_uuid=None):
     distributor_api = DistributorAPI()
     if dist_uuid:

--- a/test/katello/tests/core/system/system_data.py
+++ b/test/katello/tests/core/system/system_data.py
@@ -49,6 +49,17 @@ SYSTEM_GROUP_HISTORY = [
   }
 ]
 
+SYSTEM_GROUP_SYSTEMS = [
+  {
+    "id": "d49f6d91-0bb3-43f0-9881-dc051fa818c7",
+    "name": "FakeSystem345"
+  },
+  {
+    "id": "92eb02a6-0d33-4f89-885c-55aebedaf0e1",
+    "name": "Winterfell"
+  }
+]
+
 SYSTEMS = [
   {
     "guests": [

--- a/test/katello/tests/core/system/system_group_add_systems_test.py
+++ b/test/katello/tests/core/system/system_group_add_systems_test.py
@@ -33,11 +33,12 @@ class SystemGroupAddSystemsTest(CLIActionTestCase):
 
     ORG = organization_data.ORGS[0]
     SYSTEM_GROUP = system_data.SYSTEM_GROUPS[1]
+    SYSTEMS = system_data.SYSTEMS
 
     OPTIONS = {
         'org': ORG['name'],
         'name': SYSTEM_GROUP['name'],
-        'system_uuids' : ['fgadg3943-daf323','34ad5-34ad3-h6ddss4']
+        'system_uuids' : [SYSTEMS[0]['uuid'], SYSTEMS[1]['uuid']]
     }
 
     def setUp(self):
@@ -49,6 +50,8 @@ class SystemGroupAddSystemsTest(CLIActionTestCase):
 
         self.mock(self.action.api, 'add_systems', self.SYSTEM_GROUP)
         self.mock(self.module, 'get_system_group', self.SYSTEM_GROUP)
+        self.mock(self.module, 'get_systems', self.SYSTEMS)
+        self.mock(self.action.api, 'system_group_systems', [])
 
     def test_it_calls_system_group_add_systems_api(self):
         self.action.run()

--- a/test/katello/tests/core/system/system_group_remove_systems_test.py
+++ b/test/katello/tests/core/system/system_group_remove_systems_test.py
@@ -33,11 +33,13 @@ class SystemGroupRemoveSystemsTest(CLIActionTestCase):
 
     ORG = organization_data.ORGS[0]
     SYSTEM_GROUP = system_data.SYSTEM_GROUPS[1]
+    SYSTEM_GROUP_SYSTEMS = system_data.SYSTEM_GROUP_SYSTEMS
+    SYSTEMS = system_data.SYSTEMS
 
     OPTIONS = {
         'org': ORG['name'],
         'name': SYSTEM_GROUP['name'],
-        'system_uuids' : ['fgadg3943-daf323','34ad5-34ad3-h6ddss4']
+        'system_uuids' : [SYSTEMS[0]['uuid'], SYSTEMS[1]['uuid']]
     }
 
     def setUp(self):
@@ -49,14 +51,16 @@ class SystemGroupRemoveSystemsTest(CLIActionTestCase):
 
         self.mock(self.action.api, 'remove_systems', self.SYSTEM_GROUP)
         self.mock(self.module, 'get_system_group', self.SYSTEM_GROUP)
+        self.mock(self.module, 'get_systems', self.SYSTEMS)
+        self.mock(self.action.api, 'system_group_systems', self.SYSTEM_GROUP_SYSTEMS)
 
     def test_it_calls_system_group_remove_systems_api(self):
         self.action.run()
         self.action.api.remove_systems.assert_called_once_with(self.OPTIONS['org'], self.SYSTEM_GROUP['id'], self.OPTIONS['system_uuids'])
 
-    def test_it_returns_error_when_adding_failed(self):
+    def test_it_returns_error_when_removing_failed(self):
         self.mock(self.action.api, 'remove_systems', None)
         self.assertEqual(self.action.run(), os.EX_DATAERR)
 
-    def test_it_success_on_successful_add_of_systems(self):
+    def test_it_success_on_successful_remove_of_systems(self):
         self.assertEqual(self.action.run(), os.EX_OK)


### PR DESCRIPTION
This commit contains a few changes to improve the user behavior
when a user performs either the add_systems or remove_systems
command for a system_group.  The intent is to better inform
the user of what actually happened as a result of the request.

The following are a few examples:
1. user adds 2 new systems to a group:

katello> system_group add_systems --org ACME_Corporation --name group1 --system_uuids "e9ee386f-b6f6-4177-b216-20d99461399b, 79e8671a-fc65-421d-9c68-2c7ef4f27cf5"
Successfully added systems [ e9ee386f-b6f6-4177-b216-20d99461399b, 79e8671a-fc65-421d-9c68-2c7ef4f27cf5 ] to system group [ group1 ].
katello>
1. user attempts to add systems, but one of them is invalid
   Note: no change will be made to the group

katello> system_group add_systems --org ACME_Corporation --name group1 --system_uuids "e9ee386f-b6f6-4177-b216-20d99461399b, 79e8671a"
Could not find Systems [ 79e8671a ] in Org [ ACME_Corporation ]
katello>
1. user attempts to add systems, but one is already in the group

katello> system_group add_systems --org ACME_Corporation --name group1 --system_uuids "e9ee386f-b6f6-4177-b216-20d99461399b, 79e8671a-fc65-421d-9c68-2c7ef4f27cf5"
Successfully added systems [ e9ee386f-b6f6-4177-b216-20d99461399b ] to system group [ group1 ].
Note: Systems [ 79e8671a-fc65-421d-9c68-2c7ef4f27cf5 ] were already members of the system group; therefore, no changes were made for them.
1. user attempts to add systems, but all of them are already in the group

katello> system_group add_systems --org ACME_Corporation --name group1 --system_uuids "e9ee386f-b6f6-4177-b216-20d99461399b, 79e8671a-fc65-421d-9c68-2c7ef4f27cf5"
Systems [ e9ee386f-b6f6-4177-b216-20d99461399b, 79e8671a-fc65-421d-9c68-2c7ef4f27cf5 ] are already members of the system group; therefore, no changes were made to system group [ group1 ].
katello>

Similar behaviors exist for 'remove_systems'.
