### PR TITLE
1012572: Check the upload type against the repo's content type

### DIFF
--- a/test/katello/tests/core/content_upload/content_upload_test.py
+++ b/test/katello/tests/core/content_upload/content_upload_test.py
@@ -38,6 +38,7 @@ class ContentUploadTest(CLIActionTestCase):
         self.mock(self.module, 'generate_puppet_data', [{}, {}])
         self.mock(self.module, 'generate_rpm_data', [{}, {}])
         self.mock(os.path, 'isfile', True)
+        self.mock(self.action, '_valid_upload_type', True)
 
     def test_yum_content_upload(self):
         content_upload = CONTENT_UPLOADS[0]


### PR DESCRIPTION
Why are we checking the content type in the CLI and not the API?
1. The content type is not being passed to the API. The content type is used to parse the upload's metadata which happens in the CLI and not API (we copied pulp's python code over to do the metadata parsing).
2. It's better to do it before we upload the package than at the very end. If we were to pass the content type to the API, we probably wouldn't do it until import_into_repo which is the last call (after the package or module gets uploaded). This would mean the user would have to sit through actually uploading the package before knowing it wasn't valid.
