### PR TITLE
1018236: Node Sync: Update to support reporting unsuccessful/errors

### DIFF
--- a/src/katello/client/core/node.py
+++ b/src/katello/client/core/node.py
@@ -21,8 +21,8 @@ from katello.client.api.node import NodeAPI
 from katello.client.api.utils import get_node, get_environment
 from katello.client.cli.base import opt_parser_add_node, opt_parser_add_org
 from katello.client.lib.ui.progress import run_spinner_in_bg, wait_for_async_task
-from katello.client.lib.async import AsyncTask
-
+from katello.client.lib.ui.formatters import format_node_sync_errors
+from katello.client.lib.async import AsyncTask, evaluate_task_status
 
 
 # base node action =========================================================
@@ -102,7 +102,12 @@ class Sync(NodeAction):
         sync_tasks = self.api.sync(node_id, env_id)
         task = AsyncTask(sync_tasks)
         run_spinner_in_bg(wait_for_async_task, [task], message=message)
-        print _("Sync Complete")
+
+        return evaluate_task_status(task,
+            ok =     _("Sync of environment [ %s ] completed successfully.") % env_name,
+            failed = _("Sync of environment [ %s ] failed") % env_name,
+            error_formatter = format_node_sync_errors
+        )
 
 class BaseUpdate(NodeAction):
 

--- a/src/katello/client/lib/async.py
+++ b/src/katello/client/lib/async.py
@@ -77,7 +77,8 @@ class AsyncTask():
         return not self.is_running()
 
     def failed(self):
-        return len([t for t in self._tasks if t['state'] in ('error', 'timed out', 'failed')])
+        return (len([t for t in self._tasks if t['state'] in ('error', 'timed out', 'failed')]) +
+                len(self.repo_errors()))
 
     def canceled(self):
         return len([t for t in self._tasks if t['state'] in ('cancelled', 'canceled')])
@@ -108,6 +109,19 @@ class AsyncTask():
         for task in self._tasks:
             if isinstance(task["progress"], dict):
                 errors += task['progress'].get('error_details', [])
+        return errors
+
+    def repo_errors(self):
+        errors = []
+        for task in self._tasks:
+            try:
+                if isinstance(task['result'], dict):
+                    errors += task['result'].get('details', {}).get('repository', {}). \
+                              get('details', {}).get('errors', [])
+            except KeyError:
+                # if one of the keys doesn't exist, then there weren't any errors
+                pass
+
         return errors
 
     def errors(self):       

--- a/src/katello/client/lib/ui/formatters.py
+++ b/src/katello/client/lib/ui/formatters.py
@@ -77,6 +77,11 @@ def format_sync_errors(task):
     return "\n".join([e for e in error_list if e])
 
 
+def format_node_sync_errors(task):
+    error_list = [e["details"]["message"] for e in task.repo_errors()]
+    return "\n".join(error_list)
+
+
 def format_task_errors(errors):
     """
     Format errors returned from AsyncTask

--- a/test/katello/tests/core/node/node_sync_test.py
+++ b/test/katello/tests/core/node/node_sync_test.py
@@ -3,6 +3,7 @@ from mock import Mock
 import os
 from katello.tests.core.action_test_utils import CLIOptionTestCase, CLIActionTestCase
 from katello.tests.core.node import node_data
+from katello.tests.core.repo import repo_data
 from katello.tests.core.organization import organization_data
 
 import katello.client.core.node
@@ -45,22 +46,22 @@ class NodeSyncTest(CLIActionTestCase):
         self.set_action(Sync())
         self.set_module(katello.client.core.node)
 
+        self.mock(self.action.api, 'sync', repo_data.SYNC_RESULT_WITHOUT_ERROR)
         self.mock(self.module, 'get_environment', self.ENV)
         self.mock(self.module, 'get_node', self.NODE)
         self.mock(self.module, 'run_spinner_in_bg')
         self.mock(self.module, 'wait_for_async_task')
+
         self.mock_printer()
 
     def test_it_syncs_with_env_id(self):
         self.mock_options(self.ENV_OPTIONS)
-        self.mock(self.action.api, 'sync') 
         self.run_action()       
         self.action.api.sync.assert_called_once_with(self.NODE['id'], self.ENV['id'])
         self.module.get_environment.assert_called_once_with(self.ORG['name'], self.ENV['name'])
 
     def test_it_syncs_without_env_id(self):
         self.mock_options(self.ALL_ENV_OPTIONS)
-        self.mock(self.action.api, 'sync')              
         self.run_action()       
         self.action.api.sync.assert_called_once_with(self.NODE['id'], None)
 


### PR DESCRIPTION
Without this change, the 'node sync' will silently ignore
a failed sync and report 'Sync Complete'.
