### PR TITLE
918157: errata list: fix the listing of errata ID

### DIFF
--- a/src/katello/client/core/errata.py
+++ b/src/katello/client/core/errata.py
@@ -81,7 +81,7 @@ class List(ErrataAction):
         view_label = self.get_option('view_label')
         view_id = self.get_option('view_id')
 
-        self.printer.add_column('errata_id', _("ID"))
+        self.printer.add_column('errata_id_exact', _("ID"))
         self.printer.add_column('title', _("Title"))
         self.printer.add_column('type', _("Type"))
 


### PR DESCRIPTION
Update to print the errata id based on what a user would
expect to see (e.g. RHBA-2013:1234 vs a long uuid)
