### PR TITLE
Spec change to deal with pylint issues

### DIFF
--- a/katello-cli.spec
+++ b/katello-cli.spec
@@ -78,7 +78,7 @@ https://fedorahosted.org/katello/wiki/TestingHowto
 %setup -q
 
 %build
-%if ! 0%{?fastbuild:1}
+%if (0%{?fedora} == 18 || 0%{?rhel} == 6) && ! 0%{?fastbuild:1}
     PYTHONPATH=src/ pylint --rcfile=./etc/spacewalk-pylint.rc --additional-builtins=_ katello
 %endif
 


### PR DESCRIPTION
Sounds like katello cli has issues with pylint 1.0 which comes with f19.
Going to file a issue to fix the pylint suggested changes, but for now
sticking with the pylint the version that we use for f18 and rhel 6. We
should try to fix this in the future
