### PR TITLE
Fixing dateutil error by setting version to 2.1

### DIFF
--- a/requirements-dev.pip
+++ b/requirements-dev.pip
@@ -1,6 +1,6 @@
 mock 
 nose 
-python-dateutil 
+python-dateutil<=2.1
 kerberos
 pep8 
 pylint==0.26.0

--- a/requirements.pip
+++ b/requirements.pip
@@ -2,4 +2,4 @@ M2Crypto
 kerberos
 iniparse
 simplejson
-python-dateutil
+python-dateutil<=2.1


### PR DESCRIPTION
See https://travis-ci.org/Katello/katello-cli/builds for examples of failing builds.
