### PR TITLE
add optional uuid to register call

### DIFF
--- a/src/katello/client/api/system.py
+++ b/src/katello/client/api/system.py
@@ -27,7 +27,7 @@ class SystemAPI(KatelloAPI):
     # pylint: disable=R0913
     def register(self, name, org, environment_id, activation_keys, cp_type,
                  release=None, sla=None, facts=None, view_id=None, installed_products=None,
-                 last_checkin=None):
+                 last_checkin=None, uuid=None):
         if environment_id is not None:
             path = "/api/environments/%s/systems" % environment_id
         else:
@@ -51,6 +51,8 @@ class SystemAPI(KatelloAPI):
             sysdata["installedProducts"] = installed_products
         if last_checkin:
             sysdata["lastCheckin"] = last_checkin
+        if uuid:
+            sysdata["uuid"] = uuid
 
         return self.server.POST(path, sysdata)[1]
 


### PR DESCRIPTION
This is needed to supply an optional UUID when creating a consumer.

https://github.com/Katello/katello/commit/5a1275739e6c3e8a5107026779dd27eb9cf64e1d is the katello code that supports this parameter.
